### PR TITLE
Support for nodejs azure sb sdk

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,6 +9,9 @@ on:
 
 permissions:
   contents: write
+  
+env:
+  DOCKERHUBPUSH: ''
 
 jobs:
 
@@ -48,15 +51,18 @@ jobs:
         username: devopsifyme
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Build and Push Docker image
+    - name: Enable Docker Hub Push
       if: github.ref == 'refs/heads/main'
+      run: echo 'DOCKERHUBPUSH=--push' >> "$GITHUB_ENV"
+
+    - name: Build and Push Docker image
       run: |
         export TAG=${{ steps.gitversion.outputs.semVer }}
         export TAGMAJOR=${{ steps.gitversion.outputs.major }}
         export TAGMAJORMINOR=${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}
         export TAGMAJORMINORPATCH=${{ steps.gitversion.outputs.majorMinorPatch }}
 
-        docker buildx bake -f docker-compose.yml -f docker-compose.amqp1.yml --push
+        docker buildx bake -f docker-compose.yml -f docker-compose.amqp1.yml ${{ env.DOCKERHUBPUSH }}
 
     - name: Archive build output
       run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: "3.9"
 services:
   rabbit:
-    image: rabbitmq:3.11.6-management
+    image: rabbitmq:3-management
+    user: rabbitmq
     ports:
       - "15672:15672"
       - "5672:5672"

--- a/src/ServiceBusEmulator.Abstractions/ServiceBusEmulator.Abstractions.csproj
+++ b/src/ServiceBusEmulator.Abstractions/ServiceBusEmulator.Abstractions.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Label="Packages">
-		<PackageReference Include="AMQPNetLite" Version="2.4.0" />
+		<PackageReference Include="AMQPNetLite" Version="2.4.5" />
 	</ItemGroup>
 
 </Project>

--- a/src/ServiceBusEmulator.RabbitMq/RabbitMqMapper.cs
+++ b/src/ServiceBusEmulator.RabbitMq/RabbitMqMapper.cs
@@ -48,7 +48,7 @@ namespace ServiceBusEmulator.RabbitMq
             {
                 message.MessageAnnotations[new Symbol(key)] = value;
             }
-            message.MessageAnnotations[new Symbol("x-opt-locked-until")] = DateTime.UtcNow.AddDays(1).ToString("o", CultureInfo.InvariantCulture);
+            message.MessageAnnotations[new Symbol("x-opt-locked-until")] = DateTime.UtcNow.AddDays(1);
 
             message.Properties = new Properties
             {

--- a/src/ServiceBusEmulator.RabbitMq/RabbitMqMapper.cs
+++ b/src/ServiceBusEmulator.RabbitMq/RabbitMqMapper.cs
@@ -48,6 +48,7 @@ namespace ServiceBusEmulator.RabbitMq
             {
                 message.MessageAnnotations[new Symbol(key)] = value;
             }
+            message.MessageAnnotations[new Symbol("x-opt-locked-until")] = DateTime.UtcNow.AddDays(1).ToString("o", CultureInfo.InvariantCulture);
 
             message.Properties = new Properties
             {
@@ -100,7 +101,7 @@ namespace ServiceBusEmulator.RabbitMq
                 DateTime creationTime = rProperties.CreationTime == DateTime.MinValue ? DateTime.UtcNow : rProperties.CreationTime;
 
                 prop.ReplyTo = rProperties.ReplyTo;
-                prop.MessageId = rProperties.MessageId;
+                prop.MessageId = rProperties.MessageId ?? Guid.NewGuid().ToString();
                 prop.CorrelationId = rProperties.CorrelationId;
                 prop.ContentType = rProperties.ContentType;
                 prop.ContentEncoding = rProperties.ContentEncoding;

--- a/src/ServiceBusEmulator/ServiceBusEmulatorHost.cs
+++ b/src/ServiceBusEmulator/ServiceBusEmulatorHost.cs
@@ -1,4 +1,5 @@
 ﻿using Amqp;
+using Amqp.Framing;
 using Amqp.Listener;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -87,6 +88,12 @@ namespace ServiceBusEmulator
             int port = Settings.Port;
             Address address = new($"amqps://localhost:{port}");
             ContainerHost host = new(new[] { address }, Settings.ServerCertificate);
+            host.AddressResolver += (c, attach) =>
+            {
+                // required for node.js SDK $cbs authentication
+                ((Target)attach.Target).Address ??= attach.LinkName;
+                return null;
+            };
 
             host.Listeners[0].HandlerFactory = _ => AzureHandler.Instance;
             host.Listeners[0].SASL.EnableAzureSaslMechanism();

--- a/test/ServiceBusEmulator.RabbitMq.Tests/Endpoints/AmqpExtensions.cs
+++ b/test/ServiceBusEmulator.RabbitMq.Tests/Endpoints/AmqpExtensions.cs
@@ -35,6 +35,8 @@ namespace ServiceBusEmulator.RabbitMq.Tests.Links
                     delivery.State = deliveryState ?? new Accepted();
                     delivery.Tag = fixture.CreateMany<byte>(16).ToArray();
 
+                    deliverySetter.PropertyType.GetField("Buffer").SetValue(delivery, new ByteBuffer(1, true));
+
                     deliverySetter.SetValue(x, delivery);
                 })
             );

--- a/test/ServiceBusEmulator.RabbitMq.Tests/RabbitMqMapperTest.cs
+++ b/test/ServiceBusEmulator.RabbitMq.Tests/RabbitMqMapperTest.cs
@@ -54,7 +54,9 @@ namespace ServiceBusEmulator.RabbitMq.Tests
                 () => Assert.Equal(expectedMessage.ApplicationProperties.FromDescribedMap(), amqpMessage.ApplicationProperties.FromDescribedMap()),
                 //() => Assert.Equal(expectedMessage.DeliveryAnnotations.FromDescribedMap(), amqpMessage.DeliveryAnnotations.FromDescribedMap()),
                 //() => Assert.Equal(expectedMessage.Footer.FromDescribedMap(), amqpMessage.Footer.FromDescribedMap()),
-                () => Assert.Equal(expectedMessage.MessageAnnotations.FromDescribedMap(), amqpMessage.MessageAnnotations.FromDescribedMap())
+                () => Assert.Equal(expectedMessage.MessageAnnotations.FromDescribedMap(), amqpMessage.MessageAnnotations.FromDescribedMap()),
+
+                () => Assert.NotNull(amqpMessage.MessageAnnotations[new Symbol("x-opt-locked-until")])
             );
         }
 

--- a/test/ServiceBusEmulator.RabbitMq.Tests/RabbitMqMapperTest.cs
+++ b/test/ServiceBusEmulator.RabbitMq.Tests/RabbitMqMapperTest.cs
@@ -56,7 +56,7 @@ namespace ServiceBusEmulator.RabbitMq.Tests
                 //() => Assert.Equal(expectedMessage.Footer.FromDescribedMap(), amqpMessage.Footer.FromDescribedMap()),
                 () => Assert.Equal(expectedMessage.MessageAnnotations.FromDescribedMap(), amqpMessage.MessageAnnotations.FromDescribedMap()),
 
-                () => Assert.NotNull(amqpMessage.MessageAnnotations[new Symbol("x-opt-locked-until")])
+                () => Assert.Equal((DateTime)amqpMessage.MessageAnnotations[new Symbol("x-opt-locked-until")], DateTime.UtcNow, TimeSpan.FromDays(2))
             );
         }
 


### PR DESCRIPTION
* support for nodejs azure sb sdk 
  * generate x-opt-locked-until for received messages 
  * generate message-id for received messages 
  * set the correct target address default on attach during CBS auth
* update amqp library
* stabilize rabbitmq in integration tests