### PR TITLE
Fix for AMQP wrong assumption that AMQP message-id is always a string

### DIFF
--- a/src/ServiceBusEmulator/Security/CbsRequestProcessor.cs
+++ b/src/ServiceBusEmulator/Security/CbsRequestProcessor.cs
@@ -59,7 +59,7 @@ namespace ServiceBusEmulator.Security
 
         private static Message GetResponseMessage(int responseCode, RequestContext requestContext)
         {
-            string messageId = requestContext.Message.Properties.GetMessageId().ToString();
+            string messageId = Convert.ToString(requestContext.Message.Properties.GetMessageId());
             requestContext.Message.Properties.SetMessageId(messageId);
             return new Message
             {

--- a/src/ServiceBusEmulator/Security/CbsRequestProcessor.cs
+++ b/src/ServiceBusEmulator/Security/CbsRequestProcessor.cs
@@ -4,6 +4,7 @@ using Amqp.Listener;
 using Microsoft.Extensions.Logging;
 using ServiceBusEmulator.Abstractions.Security;
 using System;
+using System.Globalization;
 
 namespace ServiceBusEmulator.Security
 {
@@ -59,7 +60,8 @@ namespace ServiceBusEmulator.Security
 
         private static Message GetResponseMessage(int responseCode, RequestContext requestContext)
         {
-            string messageId = Convert.ToString(requestContext.Message.Properties.GetMessageId());
+            string messageId = Convert.ToString(requestContext.Message.Properties.GetMessageId(), 
+                CultureInfo.InvariantCulture);
             requestContext.Message.Properties.SetMessageId(messageId);
             return new Message
             {

--- a/src/ServiceBusEmulator/Security/CbsRequestProcessor.cs
+++ b/src/ServiceBusEmulator/Security/CbsRequestProcessor.cs
@@ -59,11 +59,14 @@ namespace ServiceBusEmulator.Security
 
         private static Message GetResponseMessage(int responseCode, RequestContext requestContext)
         {
+            string messageId = requestContext.Message.Properties.GetMessageId().ToString();
+            requestContext.Message.Properties.SetMessageId(messageId);
             return new Message
             {
                 Properties = new Properties
                 {
-                    CorrelationId = requestContext.Message.Properties.MessageId
+                    CorrelationId = messageId,
+                    MessageId = messageId
                 },
                 ApplicationProperties = new ApplicationProperties
                 {


### PR DESCRIPTION
[AMQP specification](https://www.amqp.org/sites/amqp.org/files/amqp.pdf) says that `message-id` field can be of many type, not necessarily a `string`, however the emulator (or rather its amqp dependency library) always expect this field to be a `string` and nothing else. 

Fixes #24 

