### PR TITLE
Fix for ServiceBusProcessor error on Dispose because of drain flow

### DIFF
--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -2,7 +2,7 @@ version: "3.9"
 services:
   sbemulator:
     environment:
-      - Emulator__QueuesAndTopics=test-queue;test-topic/Subscriptions/test-sub1;test-topic/Subscriptions/test-sub2
+      - Emulator__QueuesAndTopics=test-queue;test-topic/Subscriptions/test-sub1;test-topic/Subscriptions/test-sub2;test-topic/Subscriptions/test-sub3
 
   integration:
     image: integration-tests:latest

--- a/src/ServiceBusEmulator.RabbitMq/Endpoints/RabbitMqReceiverEndpoint.cs
+++ b/src/ServiceBusEmulator.RabbitMq/Endpoints/RabbitMqReceiverEndpoint.cs
@@ -69,6 +69,12 @@ namespace ServiceBusEmulator.RabbitMq.Endpoints
 
         public override void OnFlow(FlowContext flowContext)
         {
+            if (flowContext.Link.IsDraining)
+            {
+                flowContext.Link.CompleteDrain();
+                return;
+            } 
+            
             int requestedCount = flowContext.Messages;
 
             EventingBasicConsumer consumer = new(Channel);

--- a/test/ServiceBusEmulator.IntegrationTests/Consts.cs
+++ b/test/ServiceBusEmulator.IntegrationTests/Consts.cs
@@ -7,7 +7,8 @@
         public const string TestTopicName = "test-topic";
         public const string TestSubsciption1Name = "test-topic/Subscriptions/test-sub1";
         public const string TestSubsciption2Name = "test-topic/Subscriptions/test-sub2";
-
+        public const string TestSubsciption3Name = "test-topic/Subscriptions/test-sub3";
+        
         public const string QueueCollection = "Queue";
         public const string TopicCollection = "Topic";
 

--- a/test/ServiceBusEmulator.IntegrationTests/ServiceBusProcessorTest.cs
+++ b/test/ServiceBusEmulator.IntegrationTests/ServiceBusProcessorTest.cs
@@ -1,0 +1,67 @@
+using AutoFixture;
+using Azure.Messaging.ServiceBus;
+
+namespace ServiceBusEmulator.IntegrationTests
+{
+    [Collection(Consts.TopicCollection)]
+    public class ServiceBusProcessorTest : Base
+    {
+        [Fact]
+        public async Task ThatDisposeWorks()
+        {
+            var messageBody = Fixture.Create<string>();
+
+            var serviceBusOptions = new ServiceBusProcessorOptions { AutoCompleteMessages = false, MaxConcurrentCalls = 1, PrefetchCount = 0 };
+            var serviceBusProcessor = Client.CreateProcessor(Consts.TestSubsciption3Name, serviceBusOptions);
+
+            serviceBusProcessor.ProcessMessageAsync += OnProcessMessageAsync;
+            serviceBusProcessor.ProcessErrorAsync += OnProcessErrorAsync;
+
+            await serviceBusProcessor.StartProcessingAsync();
+
+            var sender = Client.CreateSender(Consts.TestTopicName);
+            var receiver1 = Client.CreateReceiver(Consts.TestSubsciption1Name, new ServiceBusReceiverOptions
+            {
+                ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete
+            });
+            var receiver2 = Client.CreateReceiver(Consts.TestSubsciption2Name, new ServiceBusReceiverOptions
+            {
+                ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete
+            });
+
+            await sender.SendMessageAsync(new ServiceBusMessage(messageBody));
+
+            await Task.Delay(500);
+
+            var receivedMessage1 = await receiver1.ReceiveMessageAsync();
+            var nextMessage1 = await receiver1.PeekMessageAsync();
+            var receivedMessage2 = await receiver2.ReceiveMessageAsync();
+            var nextMessage2 = await receiver2.PeekMessageAsync();
+
+            Assert.Multiple(
+                () => Assert.Equal(messageBody, receivedMessage1.Body.ToString()),
+                () => Assert.Equal(messageBody, receivedMessage2.Body.ToString()),
+                () => Assert.Null(nextMessage1),
+                () => Assert.Null(nextMessage2)
+            );
+
+            await serviceBusProcessor.StopProcessingAsync();
+
+            serviceBusProcessor.ProcessMessageAsync -= OnProcessMessageAsync;
+            serviceBusProcessor.ProcessErrorAsync -= OnProcessErrorAsync;
+            await serviceBusProcessor.DisposeAsync();
+        }
+
+        private async Task OnProcessMessageAsync(ProcessMessageEventArgs args)
+        {
+            await Task.Delay(100);
+            await args.CompleteMessageAsync(args.Message, args.CancellationToken);            
+        }
+
+        private Task OnProcessErrorAsync(ProcessErrorEventArgs args)
+        {
+            await Task.Delay(100);
+            await args.CompleteMessageAsync(args.Message, args.CancellationToken);            
+        }    
+    }
+}

--- a/test/ServiceBusEmulator.IntegrationTests/ServiceBusProcessorTest.cs
+++ b/test/ServiceBusEmulator.IntegrationTests/ServiceBusProcessorTest.cs
@@ -58,10 +58,9 @@ namespace ServiceBusEmulator.IntegrationTests
             await args.CompleteMessageAsync(args.Message, args.CancellationToken);            
         }
 
-        private Task OnProcessErrorAsync(ProcessErrorEventArgs args)
+        private async Task OnProcessErrorAsync(ProcessErrorEventArgs args)
         {
-            await Task.Delay(100);
-            await args.CompleteMessageAsync(args.Message, args.CancellationToken);            
+            await Task.Delay(100);           
         }    
     }
 }


### PR DESCRIPTION
Fixing a bug with ServiceBusProcessor when Dispose it because drain flow is creating a new consumer and it is not necessary.