### PR TITLE
Implement authentication with JWT

### DIFF
--- a/src/ServiceBusEmulator.Abstractions/Options/ServiceBusEmulatorOptions.cs
+++ b/src/ServiceBusEmulator.Abstractions/Options/ServiceBusEmulatorOptions.cs
@@ -1,4 +1,5 @@
 ﻿using ServiceBusEmulator.Abstractions.Domain;
+using ServiceBusEmulator.Abstractions.Security;
 using System.Security.Cryptography.X509Certificates;
 
 namespace ServiceBusEmulator.Abstractions.Options
@@ -8,6 +9,11 @@ namespace ServiceBusEmulator.Abstractions.Options
     /// </summary>
     public class ServiceBusEmulatorOptions
     {
+        /// <summary>
+        /// Type of authentication: `Sas` or `Jwt`
+        /// </summary>
+        public AuthenticationType AuthType { get; set; } = AuthenticationType.Sas;
+
         /// <summary>
         /// Returns the <see cref="X509Certificate2"/> used to setup secure links, or null if none set.
         /// </summary>

--- a/src/ServiceBusEmulator.Abstractions/Security/AuthenticationType.cs
+++ b/src/ServiceBusEmulator.Abstractions/Security/AuthenticationType.cs
@@ -1,0 +1,8 @@
+namespace ServiceBusEmulator.Abstractions.Security
+{
+    public enum AuthenticationType
+    {
+        Sas,
+        Jwt
+    }
+}

--- a/src/ServiceBusEmulator.Host/appsettings.Development.json
+++ b/src/ServiceBusEmulator.Host/appsettings.Development.json
@@ -6,6 +6,7 @@
     }
   },
   "Emulator": {
+    "AuthType": "Sas",
     "ServerCertificateThumbprint": "7516c090f156c4868a0ab6a4631757e7cce0cbae",
     "Port": 5671,
     "RabbitMq": {

--- a/src/ServiceBusEmulator/Extensions.cs
+++ b/src/ServiceBusEmulator/Extensions.cs
@@ -1,6 +1,7 @@
 ﻿using Amqp.Listener;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using ServiceBusEmulator.Abstractions.Options;
 using ServiceBusEmulator.Abstractions.Security;
 using ServiceBusEmulator.InMemory;
@@ -24,7 +25,15 @@ namespace ServiceBusEmulator
             _ = services.AddTransient<ISecurityContext>(sp => SecurityContext.Default);
 
             _ = services.AddTransient<CbsRequestProcessor>();
-            _ = services.AddTransient<ITokenValidator>(sp => CbsTokenValidator.Default);
+            _ = services.AddTransient<ITokenValidator>(sp =>
+            {
+                var options = sp.GetRequiredService<IOptions<ServiceBusEmulatorOptions>>();
+                return options.Value.AuthType switch
+                {
+                    AuthenticationType.Sas => CbsSasTokenValidator.Default,
+                    AuthenticationType.Jwt => CbsJwtTokenValidator.Default
+                };
+            });
 
             _ = services.AddOptions<ServiceBusEmulatorOptions>().Configure(configure).PostConfigure(options =>
             {
@@ -39,7 +48,7 @@ namespace ServiceBusEmulator
                 {
                     options.ServerCertificate = new X509Certificate2(options.ServerCertificatePath, options.ServerCertificatePassword, X509KeyStorageFlags.Exportable);
                 }
-            }).BindConfiguration("Emulator"); ;
+            }).BindConfiguration("Emulator");
 
             _ = services.AddTransient<ServiceBusEmulatorHost>();
             _ = services.AddSingleton<IHostedService, ServiceBusEmulatorWorker>();

--- a/src/ServiceBusEmulator/Security/CbsJwtTokenValidator.cs
+++ b/src/ServiceBusEmulator/Security/CbsJwtTokenValidator.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.IdentityModel.Tokens;
+using ServiceBusEmulator.Abstractions.Security;
+using System.IdentityModel.Tokens.Jwt;
+
+namespace ServiceBusEmulator.Security
+{
+    internal class CbsJwtTokenValidator : ITokenValidator
+    {
+        public static CbsJwtTokenValidator Default { get; } = new();
+
+        public void Validate(string token)
+        {
+            var validationParameters = new TokenValidationParameters
+            {
+                SignatureValidator = (t, _) => new JwtSecurityToken(t),
+                ValidateIssuerSigningKey = false,
+                ValidateIssuer = false,
+                ValidateAudience = false,
+                ValidateLifetime = false
+            };
+
+            var handler = new JwtSecurityTokenHandler();
+            _ = handler.ValidateToken(token, validationParameters, out _);
+        }
+    }
+}

--- a/src/ServiceBusEmulator/Security/CbsSasTokenValidator.cs
+++ b/src/ServiceBusEmulator/Security/CbsSasTokenValidator.cs
@@ -15,9 +15,7 @@ internal class SR
 
 namespace ServiceBusEmulator.Security
 {
-
-
-    internal class CbsTokenValidator : ITokenValidator
+    internal class CbsSasTokenValidator : ITokenValidator
     {
         private const string DefaultSharedAccessKeyName = "all";
         private const string DefaultSharedAccessKey = "CLwo3FQ3S39Z4pFOQDefaiUd1dSsli4XOAj3Y9Uh1E=";
@@ -28,13 +26,13 @@ namespace ServiceBusEmulator.Security
         private const string SignedKeyName = "skn";
         private const string SignedExpiry = "se";
 
-        public static CbsTokenValidator Default { get; } = new CbsTokenValidator(DefaultSharedAccessKeyName, DefaultSharedAccessKey);
+        public static CbsSasTokenValidator Default { get; } = new CbsSasTokenValidator(DefaultSharedAccessKeyName, DefaultSharedAccessKey);
 
         public string SharedAccessKeyName { get; }
 
         public string SharedAccessKey { get; }
 
-        public CbsTokenValidator(string sharedAccessKeyName, string sharedAccessKey)
+        public CbsSasTokenValidator(string sharedAccessKeyName, string sharedAccessKey)
         {
             SharedAccessKeyName = sharedAccessKeyName ?? throw new ArgumentNullException(nameof(sharedAccessKeyName));
             SharedAccessKey = sharedAccessKey ?? throw new ArgumentNullException(nameof(sharedAccessKey));
@@ -56,8 +54,7 @@ namespace ServiceBusEmulator.Security
                 throw new ArgumentException(null, nameof(token));
             }
 
-            System.Collections.Generic.Dictionary<string, string> query = token
-[SasFullName.Length..]
+            System.Collections.Generic.Dictionary<string, string> query = token[SasFullName.Length..]
                 .Split(new[] { SasPairSeparator }, StringSplitOptions.None)
                 .Select(pair => pair.Split(new[] { SasKeyValueSeparator }, 2, StringSplitOptions.None))
                 .ToDictionary(pair => pair[0], pair => pair.Length > 1 ? pair[1] : null);

--- a/src/ServiceBusEmulator/ServiceBusEmulator.csproj
+++ b/src/ServiceBusEmulator/ServiceBusEmulator.csproj
@@ -8,6 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This allows the client application to authenticate to the emulator with `FullyQualifiedNamespace` and `DefaultAzureCredential` and avoid having different configuration code for development and production:
```C#
new ServiceBusClient(
    fullyQualifiedNamespace: "sb-local.servicebus.windows.net",
    credential: new DefaultAzureCredential()
);
```